### PR TITLE
Design tweaks

### DIFF
--- a/public/styles/main-styles.css
+++ b/public/styles/main-styles.css
@@ -16,6 +16,18 @@
 
 /** Base Styling */
 
+body,
+h1, h2, h3, h4,
+p, ul, ol, li, span {
+  font-family:
+    -apple-system,
+    BlinkMacSystemFont,
+    'Segoe UI',
+    'Roboto',
+    'Helvetica Neue',
+    sans-serif;
+}
+
 body {
   background: #eee;
 }

--- a/public/styles/main-styles.css
+++ b/public/styles/main-styles.css
@@ -57,10 +57,22 @@ p {
 
 .mdl-layout__header {
   background-color: #7D287D;
+  height: auto;
+  padding: 1rem;
+}
+
+.mdl-layout__header-row:first-child {
+  height: auto;
+  margin: 1rem auto .5rem;
+}
+
+.mdl-layout-title {
+  font-size: 2rem;
+  margin: 0;
 }
 
 .header-input-wrapper {
-  margin-bottom: 1rem;
+  margin: 0 auto;
 }
 
 .input-address {
@@ -68,10 +80,7 @@ p {
   padding: 10px;
   box-sizing: border-box;
   font-size: 1.25rem;
-}
-
-.mdl-layout-title {
-  font-size: 2rem;
+  font-family: inherit;
 }
 
 /** Basic Components */

--- a/public/styles/main-styles.css
+++ b/public/styles/main-styles.css
@@ -7,7 +7,7 @@
 }
 
 .content-wrapper {
-  max-width: 1000px;
+  max-width: 48rem;
   padding: 0 1rem;
   width: 100%;
   margin: 0 auto;

--- a/public/styles/main-styles.css
+++ b/public/styles/main-styles.css
@@ -93,9 +93,15 @@ p {
   margin-left: 0;
 }
 
+.mdl-card-title {
+  margin-top: 0;
+  margin-bottom: 1rem;
+}
+
 .mdl-card-text {
   font-size: 1.25rem;
-  line-height: 1.4;
+  line-height: 1.5;
+  margin-bottom: 0;
 }
 
 /** Representative Data */


### PR DESCRIPTION
- Consistently use San Francisco/system font instead of Roboto/Helvetica/Arial
- Better measure on script/cards
- Better spacing in the header and between elements on cards

Before:
![before](https://cloud.githubusercontent.com/assets/5074763/20469279/96ef81b2-af6c-11e6-9adc-d74aa3d1dbfc.png)

After:
![after](https://cloud.githubusercontent.com/assets/5074763/20469276/928fff8e-af6c-11e6-93ac-a418acf3e33b.png)


