### PR TITLE
Better preview images for social media

### DIFF
--- a/public/landing.html
+++ b/public/landing.html
@@ -4,12 +4,12 @@
   <meta charset="utf-8">
   <title>Call to Action – Call Congress with a tap</title>
   <meta name="description" content="Easily find and call your Congressional representative and have your voice heard!" />
-  <meta name="twitter:card" content="summary" />
+  <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:site" content="@usecalltoaction" />
   <meta name="twitter:domain" content="usecalltoaction.com">
   <meta name="twitter:title" content="Call To Action – Call Congress with a tap" />
   <meta name="twitter:description" content="Easily find and call your Congressional representative and have your voice heard!" />
-  <meta name="twitter:image" content="http://cdn.usecalltoaction.com/icon.png" />
+  <meta name="twitter:image" content="http://cdn.usecalltoaction.com/logomark-wide.png" />
   <meta property="og:type" content="website" />
   <meta property="og:site_name" content="Call to Action" />
   <meta property="og:url" content="usecalltoaction.com" />

--- a/public/landing.html
+++ b/public/landing.html
@@ -15,7 +15,7 @@
   <meta property="og:url" content="usecalltoaction.com" />
   <meta property="og:title" content="Call To Action – Call Congress with a tap" />
   <meta property="og:description" content="Easily find and call your Congressional representative and have your voice heard!" />
-  <meta property="og:image" content="http://cdn.usecalltoaction.com/icon.png">
+  <meta property="og:image" content="http://cdn.usecalltoaction.com/logomark-wide.png">
   <link rel="apple-touch-icon" sizes="180x180" href="http://cdn.usecalltoaction.com/apple-touch-icon.png">
   <link rel="icon" type="image/png" href="http://cdn.usecalltoaction.com/favicon-32x32.png" sizes="32x32">
   <link rel="icon" type="image/png" href="http://cdn.usecalltoaction.com/favicon-16x16.png" sizes="16x16">


### PR DESCRIPTION
- Instead of rescaling & cropping the logo on Facebook, use the [wide wordmark](https://slack-files.com/T2PHX5RN2-F35BJ8UGG-9cefa4a550)
- Large image card on Twitter with the same wordmark